### PR TITLE
Correct location of "installsAfter" element.

### DIFF
--- a/src/bats/devcontainer-feature.json
+++ b/src/bats/devcontainer-feature.json
@@ -33,12 +33,12 @@
       ],
       "default": "latest",
       "description": "Select version of bats-core git tag."
-    },
-    "installsAfter": [
-      "ghcr.io/devcontainers/features/git:1",
-      "ghcr.io/meaningful-ooo/devcontainer-features/fish"
-    ]
+    }
   },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/git:1",
+    "ghcr.io/meaningful-ooo/devcontainer-features/fish"
+  ],
   "keywords": [
     "testing",
     "shell",


### PR DESCRIPTION
Currently, the `installsAfter` element is a child of the `options` struct.